### PR TITLE
Update dependencies and refactor RNG usage to StdRng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,13 +214,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -277,15 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,15 +297,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.6"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+checksum = "a7f9a86e097b0d187ad0e65667c2f58b9254671e86e7dbb78036b16692eae099"
 dependencies = [
- "lazy_static",
  "libm",
  "num-integer",
  "num-iter",
  "num-traits",
+ "once_cell",
  "rand",
  "serde",
  "smallvec",
@@ -431,31 +423,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom",
 ]
@@ -590,12 +587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,10 +644,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -736,6 +730,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-num-bigint-dig = { version = "0.8", features = [
+num-bigint-dig = { version = "0.9.1", features = [
     "zeroize",
     "prime",
     "rand",
@@ -16,7 +16,7 @@ num-bigint-dig = { version = "0.8", features = [
 ] }
 num-traits = "0.2"
 num-integer = "0.1"
-rand = "0.8"
+rand = "0.9.3"
 zeroize = { version = "1.8", features = ["derive"] }
 thiserror = "2"
 # Constant-time modular arithmetic for the decryption hot path (SECURITY-2).

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,7 +4,8 @@
 use num_bigint_dig::{BigUint, ModInverse, RandBigInt};
 use num_integer::Integer;
 use num_traits::{One, Zero};
-use rand::rngs::OsRng;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::util::l_function;
@@ -214,7 +215,7 @@ impl KeyPair {
             });
         }
 
-        let mut rng = OsRng;
+        let mut rng = StdRng::from_os_rng();
         let p_bits = bit_length / 3;
         let q_bits = bit_length - (2 * p_bits);
 

--- a/src/okuchi.rs
+++ b/src/okuchi.rs
@@ -4,7 +4,8 @@
 use num_bigint_dig::{BigUint, RandBigInt};
 use num_integer::Integer;
 use num_traits::{One, Zero};
-use rand::rngs::OsRng;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 use crate::ciphertext::Ciphertext;
 use crate::error::{Error, Result};
@@ -52,7 +53,7 @@ impl Okuchi {
             return Err(Error::PlaintextTooLarge);
         }
 
-        let mut rng = OsRng;
+        let mut rng = StdRng::from_os_rng();
 
         // OU requires gcd(r, n) = 1. With n = p²q the failure probability is
         // ≈ 1/p + 1/q. This is negligible but the protocol is undefined otherwise.

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,8 @@ use crypto_bigint::modular::{BoxedMontyForm, BoxedMontyParams};
 use crypto_bigint::{BoxedUint, Odd};
 use num_bigint_dig::{BigUint, RandPrime};
 use num_traits::One;
-use rand::rngs::OsRng;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 use crate::{Error, Result};
 
@@ -98,6 +99,6 @@ pub fn generate_prime(bits: usize) -> Result<BigUint> {
             "prime bit length must be >= 2".into(),
         ));
     }
-    let mut rng = OsRng;
+    let mut rng = StdRng::from_os_rng();
     Ok(rng.gen_prime(bits)) // gen_prime uses Miller-Rabin internally
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
You can open multiple PRs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the PR -->
This PR targets an update of `rand` to version 0.9.3 to get rid of a (low) CVE report for some `rand` versions. Additionally, this update also mandates an update of `num-bigint-dig` to the latest version.

Although rand v0.9.3 still exposes OsRng, we move away from it in this PR and use StdRng instead. We do this, in order to simplify future version updates of the rand abd num-bigint-dig crates. In particular, num-bigint-dig does not yet use the newly introduced `RngExt` trait by the rand crate, which blocks updating to rand 0.10.1 directly.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
